### PR TITLE
Immutable settings

### DIFF
--- a/scraper/src/config/config_validator.py
+++ b/scraper/src/config/config_validator.py
@@ -25,6 +25,11 @@ class ConfigValidator:
                                                     list):
             raise Exception('stop_urls should be list')
 
+        # Custom settings must be a dict
+        if self.config.custom_settings and not isinstance(self.config.custom_settings,
+                                                    dict):
+            raise Exception('custom_settings must be a dictionary')
+
         if self.config.js_render and not isinstance(self.config.js_render,
                                                     bool):
             raise Exception('js_render should be boolean')

--- a/scraper/src/index.py
+++ b/scraper/src/index.py
@@ -40,6 +40,7 @@ def run_config(config):
         config.app_id,
         config.api_key,
         config.index_uid,
+        config.custom_settings
     )
 
     root_module = 'src.' if __name__ == '__main__' else 'scraper.src.'

--- a/scraper/src/meilisearch_helper.py
+++ b/scraper/src/meilisearch_helper.py
@@ -107,11 +107,7 @@ class MeiliSearchHelper:
         self.__delete_and_create_index(index_uid)
         self.meilisearch_index = self.__delete_and_create_index(index_uid)
         settings = {**MeiliSearchHelper.SETTINGS, **custom_settings}
-        try:
-            self.meilisearch_index.update_settings(settings)
-        except Exception:
-            print("MeiliSearchApiError: Settings are badly formatted. ")
-            sys.exit()
+        self.meilisearch_index.update_settings(settings)
 
     def add_records(self, records, url, from_sitemap):
         """Add new records to the index"""

--- a/scraper/src/meilisearch_helper.py
+++ b/scraper/src/meilisearch_helper.py
@@ -2,7 +2,6 @@
 Wrapper on top of the MeiliSearch API client"""
 
 import meilisearch
-import sys
 from builtins import range
 
 def remove_bad_encoding(value):

--- a/scraper/src/meilisearch_helper.py
+++ b/scraper/src/meilisearch_helper.py
@@ -2,6 +2,7 @@
 Wrapper on top of the MeiliSearch API client"""
 
 import meilisearch
+import sys
 from builtins import range
 
 def remove_bad_encoding(value):
@@ -101,11 +102,16 @@ class MeiliSearchHelper:
         'acceptNewFields': False
     }
 
-    def __init__(self, host_url, api_key, index_uid):
+    def __init__(self, host_url, api_key, index_uid, custom_settings):
         self.meilisearch_client = meilisearch.Client(host_url, api_key)
         self.__delete_and_create_index(index_uid)
         self.meilisearch_index = self.__delete_and_create_index(index_uid)
-        self.meilisearch_index.update_settings(MeiliSearchHelper.SETTINGS)
+        settings = {**MeiliSearchHelper.SETTINGS, **custom_settings}
+        try:
+            self.meilisearch_index.update_settings(settings)
+        except Exception:
+            print('MeiliSearchApiError: Settings are badly formatted. Please visit the API references of the settings https://docs.meilisearch.com/references/settings.html')
+            sys.exit()
 
     def add_records(self, records, url, from_sitemap):
         """Add new records to the index"""

--- a/scraper/src/meilisearch_helper.py
+++ b/scraper/src/meilisearch_helper.py
@@ -110,7 +110,7 @@ class MeiliSearchHelper:
         try:
             self.meilisearch_index.update_settings(settings)
         except Exception:
-            print('MeiliSearchApiError: Settings are badly formatted. Please visit the API references of the settings https://docs.meilisearch.com/references/settings.html')
+            print("MeiliSearchApiError: Settings are badly formatted. ")
             sys.exit()
 
     def add_records(self, records, url, from_sitemap):

--- a/scraper/src/tests/config_loader/abstract.py
+++ b/scraper/src/tests/config_loader/abstract.py
@@ -7,7 +7,7 @@ def config(additional_config={}):
         'allowed_domains': 'allowed_domains',
         'api_key': 'api_key',
         'app_id': 'app_id',
-        'custom_settings': 'custom_settings',
+        'custom_settings': {},
         'hash_strategy': 'hash_strategy',
         'index_uid': 'index_uid',
         'selectors': [],


### PR DESCRIPTION
Using the custom settings to give the desired settings they will be added before documentation addition on every scrap

The error handling on the settings should stay there until the Python SDK has a proper error handler. 

fixes: #14 