### PR TITLE
Update meilisearch-python version following MeiliSearch bump to v0.11

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 Scrapy = "==1.5.0"
 selenium = "==3.141.0"
 pytest = "==3.10.0"
-meilisearch = "==0.9.0"
+meilisearch = "==0.11.0"
 requests-iap = "==0.2.0"
 
 [dev-packages]

--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ Websites that need JavaScript for rendering are passed through ChromeDriver.<br>
 
 This package is compatible with the following MeiliSearch versions:
 - `v0.10.X`
+- `v0.11.X`
 
 ## 👩‍💻 Development Workflow
 

--- a/scraper/src/meilisearch_helper.py
+++ b/scraper/src/meilisearch_helper.py
@@ -129,7 +129,7 @@ class MeiliSearchHelper:
         except Exception:
             print("The index " + index_uid + " does not exist. Creating...")
 
-        return self.meilisearch_client.create_index(uid=index_uid, primary_key='objectID')
+        return self.meilisearch_client.create_index(index_uid, {'primaryKey': 'objectID'})
 
 # Algolia's settings:
     # {"minWordSizefor1Typo"=>3,


### PR DESCRIPTION
**[This PR](https://github.com/meilisearch/meilisearch-python/pull/88) needs to be merged and the package to be released before merging this PR.**