### PR TITLE
Fixes bug with custom settings

### DIFF
--- a/scraper/src/config/config_loader.py
+++ b/scraper/src/config/config_loader.py
@@ -26,7 +26,7 @@ class ConfigLoader:
     allowed_domains = None
     api_key = None
     app_id = None
-    custom_settings = None
+    custom_settings = {}
     extra_records = []
     index_uid = None
     index_uid_tmp = None

--- a/scraper/src/meilisearch_helper.py
+++ b/scraper/src/meilisearch_helper.py
@@ -103,15 +103,11 @@ class MeiliSearchHelper:
 
     def __init__(self, host_url, api_key, index_uid, custom_settings):
         self.meilisearch_client = meilisearch.Client(host_url, api_key)
-        self.__delete_and_create_index(index_uid)
         self.meilisearch_index = self.__delete_and_create_index(index_uid)
         self.add_settings(MeiliSearchHelper.SETTINGS, custom_settings)
 
     def add_settings(self, default_settings, custom_settings):
-        if custom_settings is not None:
-            settings = {**default_settings, **custom_settings}
-        else:
-            settings = default_settings
+        settings = {**default_settings, **custom_settings}
         self.meilisearch_index.update_settings(settings)
 
     def add_records(self, records, url, from_sitemap):

--- a/scraper/src/meilisearch_helper.py
+++ b/scraper/src/meilisearch_helper.py
@@ -105,7 +105,13 @@ class MeiliSearchHelper:
         self.meilisearch_client = meilisearch.Client(host_url, api_key)
         self.__delete_and_create_index(index_uid)
         self.meilisearch_index = self.__delete_and_create_index(index_uid)
-        settings = {**MeiliSearchHelper.SETTINGS, **custom_settings}
+        self.add_settings(MeiliSearchHelper.SETTINGS, custom_settings)
+
+    def add_settings(self, default_settings, custom_settings):
+        if custom_settings is not None:
+            settings = {**default_settings, **custom_settings}
+        else:
+            settings = default_settings
         self.meilisearch_index.update_settings(settings)
 
     def add_records(self, records, url, from_sitemap):

--- a/scraper/src/tests/config_loader/abstract.py
+++ b/scraper/src/tests/config_loader/abstract.py
@@ -7,7 +7,7 @@ def config(additional_config={}):
         'allowed_domains': 'allowed_domains',
         'api_key': 'api_key',
         'app_id': 'app_id',
-        'custom_settings': {},
+        'custom_settings': None,
         'hash_strategy': 'hash_strategy',
         'index_uid': 'index_uid',
         'selectors': [],


### PR DESCRIPTION
Fixes: #26 

Scenarios: 
- No `custom_settings`: ✅
- Good `custom_settings`: ✅
- Non existing `custom_settings` attributes : MeiliSearch returns a 400 `Bad Request`
- Bad type for `custom_settings`: Doc scraper returns an error  
```
Exception: custom_settings must be a dictionary
```


