### PR TITLE
Remove unwanted transform for None value to 'null'

### DIFF
--- a/scraper/src/meilisearch_helper.py
+++ b/scraper/src/meilisearch_helper.py
@@ -8,9 +8,7 @@ def remove_bad_encoding(value):
     return value.replace('&#x27;', "'")
 
 def clean_one_field(value):
-    if value is None:
-        return 'null'
-    elif isinstance(value, bool):
+    if isinstance(value, bool):
         return str(value)
     elif isinstance(value, str):
         return remove_bad_encoding(value)


### PR DESCRIPTION
Empty fields in documents are filled with 'null' string. I do not think this is a wanted behavior and we do have this issue when searching for null on docs.meilisearch.com

<img width="769" alt="Screenshot 2020-06-10 at 17 53 11" src="https://user-images.githubusercontent.com/10537452/84289833-43fc7b00-ab43-11ea-8708-d440da7051e0.png">

here are the results with the fix

<img width="849" alt="Capture d’écran 2020-06-10 à 18 07 10" src="https://user-images.githubusercontent.com/10537452/84291394-511a6980-ab45-11ea-9e02-6ec0474d8348.png">

