### PR TITLE
Removed unreachable code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ src/strategies/__pycache__/
 *.pyc
 .env
 update.sh
+.python-version
 
 *yarn.lock
 

--- a/scraper/src/config/config_loader.py
+++ b/scraper/src/config/config_loader.py
@@ -8,7 +8,6 @@ Load the config json file.
 from collections import OrderedDict
 import json
 import os
-import sys
 import copy
 
 from .config_validator import ConfigValidator

--- a/scraper/src/config/config_loader.py
+++ b/scraper/src/config/config_loader.py
@@ -102,7 +102,6 @@ class ConfigLoader:
             return data
         except ValueError as value_error:
             raise ValueError('CONFIG is not a valid JSON') from value_error
-            sys.exit(EXIT_CODE_WRONG_CONFIG)
 
     def _parse(self):
         # Parse Env

--- a/scraper/src/documentation_spider.py
+++ b/scraper/src/documentation_spider.py
@@ -10,7 +10,6 @@ from scrapy.spiders import SitemapSpider
 from scrapy.spiders.sitemap import regex
 import re
 import os
-import sys
 
 # End of import for the sitemap behavior
 

--- a/scraper/src/documentation_spider.py
+++ b/scraper/src/documentation_spider.py
@@ -160,7 +160,6 @@ class DocumentationSpider(CrawlSpider, SitemapSpider):
             self.reason_to_stop = "Too much hits, Docs-Scraper only handle {} records".format(
                 int(self.nb_hits_max))
             raise ValueError(self.reason_to_stop)
-            sys.exit(EXIT_CODE_EXCEEDED_RECORDS)
 
     def parse_from_sitemap(self, response):
         if self.reason_to_stop is not None:


### PR DESCRIPTION
In both cases where I removed the `sys.exit` line there is a `raise` immediately preceding it so it is impossible to reach the `sys.exit`