### PR TITLE
Update pylint from 2.6.2 to 2.7.4  #114

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ requests-iap = "==0.2.0"
 python-keycloak-client = "==0.2.3"
 
 [dev-packages]
-pylint = "==2.6.2"
+pylint = "==2.7.4"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "627a04e50a9b740d4412f17ae6d03c051068aaddee0c2a86e0f7fbf17ee35cc0"
+            "sha256": "d5c72bdcde1b70a84686fd58c7ea328114b6aed01cf3e64944cb64aef08f24a9"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,6 +21,7 @@
                 "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
                 "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.3.0"
         },
         "automat": {
@@ -84,6 +85,7 @@
                 "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa",
                 "sha256:f864054d66fd9118f2e67044ac8981a54775ec5b67aed0441892edb553d21da5"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.0.0"
         },
         "constantly": {
@@ -95,26 +97,28 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:066bc53f052dfeda2f2d7c195cf16fb3e5ff13e1b6b7415b468514b40b381a5b",
-                "sha256:0923ba600d00718d63a3976f23cab19aef10c1765038945628cd9be047ad0336",
-                "sha256:2d32223e5b0ee02943f32b19245b61a62db83a882f0e76cc564e1cec60d48f87",
-                "sha256:4169a27b818de4a1860720108b55a2801f32b6ae79e7f99c00d79f2a2822eeb7",
-                "sha256:57ad77d32917bc55299b16d3b996ffa42a1c73c6cfa829b14043c561288d2799",
-                "sha256:5ecf2bcb34d17415e89b546dbb44e73080f747e504273e4d4987630493cded1b",
-                "sha256:600cf9bfe75e96d965509a4c0b2b183f74a4fa6f5331dcb40fb7b77b7c2484df",
-                "sha256:66b57a9ca4b3221d51b237094b0303843b914b7d5afd4349970bb26518e350b0",
-                "sha256:93cfe5b7ff006de13e1e89830810ecbd014791b042cbe5eec253be11ac2b28f3",
-                "sha256:9e98b452132963678e3ac6c73f7010fe53adf72209a32854d55690acac3f6724",
-                "sha256:df186fcbf86dc1ce56305becb8434e4b6b7504bc724b71ad7a3239e0c9d14ef2",
-                "sha256:fec7fb46b10da10d9e1d078d1ff8ed9e05ae14f431fdbd11145edd0550b9a964"
+                "sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d",
+                "sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959",
+                "sha256:240f5c21aef0b73f40bb9f78d2caff73186700bf1bc6b94285699aff98cc16c6",
+                "sha256:26965837447f9c82f1855e0bc8bc4fb910240b6e0d16a664bb722df3b5b06873",
+                "sha256:37340614f8a5d2fb9aeea67fd159bfe4f5f4ed535b1090ce8ec428b2f15a11f2",
+                "sha256:3d10de8116d25649631977cb37da6cbdd2d6fa0e0281d014a5b7d337255ca713",
+                "sha256:3d8427734c781ea5f1b41d6589c293089704d4759e34597dce91014ac125aad1",
+                "sha256:7ec5d3b029f5fa2b179325908b9cd93db28ab7b85bb6c1db56b10e0b54235177",
+                "sha256:8e56e16617872b0957d1c9742a3f94b43533447fd78321514abbe7db216aa250",
+                "sha256:de4e5f7f68220d92b7637fc99847475b59154b7a1b3868fb7385337af54ac9ca",
+                "sha256:eb8cc2afe8b05acbd84a43905832ec78e7b3873fb124ca190f574dca7389a87d",
+                "sha256:ee77aa129f481be46f8d92a1a7db57269a2f23052d5f2433b4621bb457081cc9"
             ],
-            "version": "==3.4.6"
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.7"
         },
         "cssselect": {
             "hashes": [
                 "sha256:f612ee47b749c877ebae5bb77035d8f4202c6ad0f0fc1271b3c18ad6c4468ecf",
                 "sha256:f95f8dedd925fd8f54edb3d2dfb44c190d9d18512377d3c1e2388d16126879bc"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.0"
         },
         "ecdsa": {
@@ -122,6 +126,7 @@
                 "sha256:64c613005f13efec6541bb0a33290d0d03c27abab5f15fbab20fb0ee162bdd8e",
                 "sha256:e108a5fe92c67639abae3260e43561af914e7fd0d27bae6d2ec1312ae7934dfe"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.14.1"
         },
         "hyperlink": {
@@ -136,6 +141,7 @@
                 "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6",
                 "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.10"
         },
         "incremental": {
@@ -157,6 +163,7 @@
                 "sha256:5327c2136353cb965b6b4ba564af002fd458691b8e30d3bd6b14c474d92c6b25",
                 "sha256:cb7aaa577fefe2aa6f229ccf4d058e05f44e0178a98c8fb70ee4d95acfabb423"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==0.2.0"
         },
         "itemloaders": {
@@ -164,6 +171,7 @@
                 "sha256:1277cd8ca3e4c02dcdfbc1bcae9134ad89acfa6041bd15b4561c6290203a0c96",
                 "sha256:4cb46a0f8915e910c770242ae3b60b1149913ed37162804f1e40e8535d6ec497"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.0.4"
         },
         "jmespath": {
@@ -171,6 +179,7 @@
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.0"
         },
         "lxml": {
@@ -228,6 +237,7 @@
                 "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5",
                 "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==20.9"
         },
         "parsel": {
@@ -242,12 +252,14 @@
                 "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
                 "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.13.1"
         },
         "protego": {
             "hashes": [
                 "sha256:a682771bc7b51b2ff41466460896c1a5a653f9a1e71639ef365a72e66d8734b4"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.1.16"
         },
         "py": {
@@ -255,19 +267,42 @@
                 "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
                 "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.10.0"
         },
         "pyasn1": {
             "hashes": [
+                "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359",
+                "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576",
+                "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf",
+                "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7",
                 "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d",
-                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"
+                "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00",
+                "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8",
+                "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86",
+                "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12",
+                "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776",
+                "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba",
+                "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2",
+                "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"
             ],
             "version": "==0.4.8"
         },
         "pyasn1-modules": {
             "hashes": [
+                "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8",
+                "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199",
+                "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811",
+                "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed",
+                "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4",
                 "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e",
-                "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74"
+                "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74",
+                "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb",
+                "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45",
+                "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd",
+                "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0",
+                "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d",
+                "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"
             ],
             "version": "==0.2.8"
         },
@@ -276,6 +311,7 @@
                 "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
                 "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.20"
         },
         "pydispatcher": {
@@ -290,6 +326,7 @@
                 "sha256:a5c70a06e1f33d81ef25eecd50d50bd30e34de1ca8b2b9fa3fe0daaabcf69bf7",
                 "sha256:b70b15f89dc69b993d8a8d32c299032d5355c82f9b5b7e851d1a6d706dffe847"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==2.0.1"
         },
         "pyopenssl": {
@@ -297,6 +334,7 @@
                 "sha256:4c231c759543ba02560fcd2480c48dcec4dae34c9da7d3747c508227e0624b51",
                 "sha256:818ae18e06922c066f777a33f1fca45786d85edfe71cd043de6379337a7f274b"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==20.0.1"
         },
         "pyparsing": {
@@ -304,6 +342,7 @@
                 "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
                 "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.4.7"
         },
         "pytest": {
@@ -341,6 +380,7 @@
                 "sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804",
                 "sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==2.25.1"
         },
         "requests-iap": {
@@ -356,6 +396,7 @@
                 "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2",
                 "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"
             ],
+            "markers": "python_version >= '3.5' and python_version < '4'",
             "version": "==4.7.2"
         },
         "scrapy": {
@@ -386,6 +427,7 @@
                 "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
         "toml": {
@@ -393,6 +435,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "twisted": {
@@ -400,6 +443,7 @@
                 "sha256:77544a8945cf69b98d2946689bbe0c75de7d145cdf11f391dd487eae8fc95a12",
                 "sha256:aab38085ea6cda5b378b519a0ec99986874921ee8881318626b0a3414bb2631e"
             ],
+            "markers": "python_full_version >= '3.5.4'",
             "version": "==21.2.0"
         },
         "urllib3": {
@@ -407,6 +451,7 @@
                 "sha256:2f4da4594db7e1e110a944bb1b551fdf4e6c136ad42e4234131391e21eb5b0df",
                 "sha256:e7b021f7241115872f92f43c6508082facffbd1c048e3c6e2bb9c2a157e28937"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
             "version": "==1.26.4"
         },
         "w3lib": {
@@ -470,49 +515,54 @@
                 "sha256:fa939c2e2468142c9773443d4038e7c915b0cc1b670d3c9192bdc503f7ea73e9",
                 "sha256:fcc5c1f95102989d2e116ffc8467963554ce89f30a65a3ea86a4d06849c498d8"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==5.3.0"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703",
-                "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"
+                "sha256:6b0ed1af831570e500e2437625979eaa3b36011f66ddfc4ce930128610258ca9",
+                "sha256:cd80bf957c49765dce6d92c43163ff9d2abc43132ce64d4b1b47717c6d2522df"
             ],
-            "version": "==2.4.2"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.5.2"
         },
         "isort": {
             "hashes": [
                 "sha256:0a943902919f65c5684ac4e0154b1ad4fac6dcaa5d9f3426b732f1c8b5419be6",
                 "sha256:2bb1680aad211e3c9944dbce1d4ba09a989f04e238296c87fe2139faa26d655d"
             ],
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==5.8.0"
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
-                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
-                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
-                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
-                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
-                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
-                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
-                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
-                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
-                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
-                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
-                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
-                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
-                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
-                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
-                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
-                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
-                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
-                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
-                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
-                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
+                "sha256:17e0967ba374fc24141738c69736da90e94419338fd4c7c7bef01ee26b339653",
+                "sha256:1fee665d2638491f4d6e55bd483e15ef21f6c8c2095f235fef72601021e64f61",
+                "sha256:22ddd618cefe54305df49e4c069fa65715be4ad0e78e8d252a33debf00f6ede2",
+                "sha256:24a5045889cc2729033b3e604d496c2b6f588c754f7a62027ad4437a7ecc4837",
+                "sha256:410283732af311b51b837894fa2f24f2c0039aa7f220135192b38fcc42bd43d3",
+                "sha256:4732c765372bd78a2d6b2150a6e99d00a78ec963375f236979c0626b97ed8e43",
+                "sha256:489000d368377571c6f982fba6497f2aa13c6d1facc40660963da62f5c379726",
+                "sha256:4f60460e9f1eb632584c9685bccea152f4ac2130e299784dbaf9fae9f49891b3",
+                "sha256:5743a5ab42ae40caa8421b320ebf3a998f89c85cdc8376d6b2e00bd12bd1b587",
+                "sha256:85fb7608121fd5621cc4377a8961d0b32ccf84a7285b4f1d21988b2eae2868e8",
+                "sha256:9698110e36e2df951c7c36b6729e96429c9c32b3331989ef19976592c5f3c77a",
+                "sha256:9d397bf41caad3f489e10774667310d73cb9c4258e9aed94b9ec734b34b495fd",
+                "sha256:b579f8acbf2bdd9ea200b1d5dea36abd93cabf56cf626ab9c744a432e15c815f",
+                "sha256:b865b01a2e7f96db0c5d12cfea590f98d8c5ba64ad222300d93ce6ff9138bcad",
+                "sha256:bf34e368e8dd976423396555078def5cfc3039ebc6fc06d1ae2c5a65eebbcde4",
+                "sha256:c6938967f8528b3668622a9ed3b31d145fab161a32f5891ea7b84f6b790be05b",
+                "sha256:d1c2676e3d840852a2de7c7d5d76407c772927addff8d742b9808fe0afccebdf",
+                "sha256:d7124f52f3bd259f510651450e18e0fd081ed82f3c08541dffc7b94b883aa981",
+                "sha256:d900d949b707778696fdf01036f58c9876a0d8bfe116e8d220cfd4b15f14e741",
+                "sha256:ebfd274dcd5133e0afae738e6d9da4323c3eb021b3e13052d8cbd0e457b1256e",
+                "sha256:ed361bb83436f117f9917d282a456f9e5009ea12fd6de8742d1a4752c3017e93",
+                "sha256:f5144c75445ae3ca2057faac03fda5a902eff196702b0a24daf1d6ce0650514b"
             ],
-            "version": "==1.4.3"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.6.0"
         },
         "mccabe": {
             "hashes": [
@@ -523,24 +573,18 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:718b74786ea7ed07aa0c58bf572154d4679f960d26e9641cc1de204a30b87fc9",
-                "sha256:e71c2e9614a4f06e36498f310027942b0f4f2fde20aebb01655b31edc63b9eaf"
+                "sha256:209d712ec870a0182df034ae19f347e725c1e615b2269519ab58a35b3fcbbe7a",
+                "sha256:bd38914c7731cdc518634a8d3c5585951302b6e2b6de60fbb3f7a0220e21eeee"
             ],
             "index": "pypi",
-            "version": "==2.6.2"
-        },
-        "six": {
-            "hashes": [
-                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
-                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
-            ],
-            "version": "==1.15.0"
+            "version": "==2.7.4"
         },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "wrapt": {

--- a/scraper/src/tests/default_strategy/default_value_test.py
+++ b/scraper/src/tests/default_strategy/default_value_test.py
@@ -1,215 +1,230 @@
 # coding: utf-8
 import lxml.html
+import pytest
+
 from .abstract import get_strategy
 
 
-class TestGetRecordsFromDomWithDefaultValue:
-    def test_default_value(self):
-        # Given
-        strategy = get_strategy({
-            'selectors': {
-                'lvl0': {
-                    'selector': 'h1',
-                    'default_value': 'Documentation'
-                },
-                'lvl1': 'h2',
-                'lvl2': 'h3',
-                'content': 'p'
-            }
-        })
-        strategy.dom = lxml.html.fromstring("""
+@pytest.fixture
+def get_selectors_lvl0():
+    selectors_lvl0_variants = {
+        'default_value': {
+            'selector': 'h1',
+            'default_value': 'Documentation'
+        },
+        'default_value_for_text': 'h1',
+        'default_value_with_global': {
+            'selector': 'h1',
+            'global': True,
+            'default_value': 'Documentation'
+        },
+        'default_value_should_not_override': {
+            'selector': 'h1',
+            'global': True,
+            'default_value': 'Documentation'
+        },
+        "default_value_empty": {
+            'selector': 'h1',
+            'default_value': 'Documentation'
+        },
+        'default_value_empty_and_global': {
+            'selector': 'h1',
+            'global': 'true',
+            'default_value': 'Documentation'
+        },
+    }
+
+    def _get_selector_lvl0(test_type):
+        return selectors_lvl0_variants.get(test_type)
+
+    return _get_selector_lvl0
+
+
+@pytest.fixture
+def get_selectors_content():
+    selectors_content_variants = {
+        'default_value': 'p',
+        'default_value_for_text': {
+            'selector': 'p',
+            'default_value': 'Documentation'
+        },
+        'default_value_with_global': 'p',
+        'default_value_should_not_override': 'p',
+        "default_value_empty": 'p',
+        'default_value_empty_and_global': 'p',
+    }
+
+    def _get_selector_content(test_type):
+        return selectors_content_variants.get(test_type)
+
+    return _get_selector_content
+
+
+@pytest.fixture
+def get_strategy_dom():
+    strategy_dom_variants = {
+        'default_value': """
         <html><body>
             <p>text</p>
             <h2>Bar</h2>
             <h3>Baz</h3>
         </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom()
-
-        # Then
-
-        # First record has the global H1
-        assert len(actual) == 3
-        assert actual[0]['type'] == 'content'
-        assert actual[0]['hierarchy']['lvl0'] == 'Documentation'
-        assert actual[0]['hierarchy']['lvl1'] is None
-        assert actual[0]['hierarchy']['lvl2'] is None
-        assert actual[0]['content'] == 'text'
-
-    def test_default_value_for_text(self):
-        # Given
-        strategy = get_strategy({
-            'selectors': {
-                'lvl0': 'h1',
-                'lvl1': 'h2',
-                'lvl2': 'h3',
-                'content': {
-                    'selector': 'p',
-                    'default_value': 'Documentation'
-                }
-            }
-        })
-        strategy.dom = lxml.html.fromstring("""
+        """,
+        'default_value_for_text': """
         <html><body>
             <h1>Foo</h1>
             <h2>Bar</h2>
             <h3>Baz</h3>
         </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom()
-
-        # Then
-
-        # First record has the global H1
-        assert len(actual) == 3
-        assert actual[0]['type'] == 'lvl0'
-        assert actual[0]['hierarchy']['lvl0'] == 'Foo'
-        assert actual[0]['hierarchy']['lvl1'] is None
-        assert actual[0]['hierarchy']['lvl2'] is None
-        assert actual[0]['content'] == 'Documentation'
-
-    def test_default_value_with_global(self):
-        # Given
-        strategy = get_strategy({
-            'selectors': {
-                'lvl0': {
-                    'selector': 'h1',
-                    'global': True,
-                    'default_value': 'Documentation'
-                },
-                'lvl1': 'h2',
-                'lvl2': 'h3',
-                'content': 'p'
-            }
-        })
-
-        strategy.dom = lxml.html.fromstring("""
+        """,
+        'default_value_with_global': """
         <html><body>
             <p>text</p>
             <h2>Bar</h2>
             <h3>Baz</h3>
         </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom()
-
-        # Then
-
-        # First record has the global H1
-        assert len(actual) == 3
-        assert actual[0]['type'] == 'content'
-        assert actual[0]['hierarchy']['lvl0'] == 'Documentation'
-        assert actual[0]['hierarchy']['lvl1'] is None
-        assert actual[0]['hierarchy']['lvl2'] is None
-        assert actual[0]['content'] == 'text'
-
-    def test_default_value_should_not_override(self):
-        # Given
-        strategy = get_strategy({
-            'selectors': {
-                'lvl0': {
-                    'selector': 'h1',
-                    'global': True,
-                    'default_value': 'Documentation'
-                },
-                'lvl1': 'h2',
-                'lvl2': 'h3',
-                'content': 'p'
-            }
-        })
-        strategy.dom = lxml.html.fromstring("""
+        """,
+        'default_value_should_not_override': """
         <html><body>
             <h1>Foo</h1>
             <p>text</p>
             <h2>Bar</h2>
             <h3>Baz</h3>
         </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom()
-
-        # Then
-
-        # First record has the global H1
-        assert len(actual) == 3
-        assert actual[0]['type'] == 'content'
-        assert actual[0]['hierarchy']['lvl0'] == 'Foo'
-        assert actual[0]['hierarchy']['lvl1'] is None
-        assert actual[0]['hierarchy']['lvl2'] is None
-        assert actual[0]['content'] == 'text'
-
-    def test_default_value_empty(self):
-        # Given
-        strategy = get_strategy({
-            'selectors': {
-                'lvl0': {
-                    'selector': 'h1',
-                    'default_value': 'Documentation'
-                },
-                'lvl1': 'h2',
-                'lvl2': 'h3',
-                'content': 'p'
-            }
-        })
-        strategy.dom = lxml.html.fromstring("""
+        """,
+        "default_value_empty": """
         <html><body>
             <h1></h1>
             <p>text</p>git
             <h2>Bar</h2>
             <h3>Baz</h3>
         </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom()
-
-        # Then
-
-        # First record has the global H1
-        assert len(actual) == 4
-        assert actual[0]['type'] == 'lvl0'
-        assert actual[0]['hierarchy']['lvl0'] == 'Documentation'
-        assert actual[0]['hierarchy']['lvl1'] is None
-        assert actual[0]['hierarchy']['lvl2'] is None
-        assert actual[0]['content'] is None
-
-    def test_default_value_empty_and_global(self):
-        # Given
-        strategy = get_strategy({
-            'selectors': {
-                'lvl0': {
-                    'selector': 'h1',
-                    'global': 'true',
-                    'default_value': 'Documentation'
-                },
-                'lvl1': 'h2',
-                'lvl2': 'h3',
-                'content': 'p'
-            }
-        })
-        strategy.dom = lxml.html.fromstring("""
+        """,
+        'default_value_empty_and_global': """
         <html><body>
             <p>text</p>
             <h2>Bar</h2>
             <h3>Baz</h3>
             <h1></h1>
         </body></html>
-        """)
+        """,
+    }
+
+    def _get_strategy_dom(test_type):
+        return strategy_dom_variants.get(test_type)
+
+    return _get_strategy_dom
+
+
+@pytest.fixture
+def get_actual_type():
+    actual_type_variants = {
+        'default_value': 'content',
+        'default_value_for_text': 'lvl0',
+        'default_value_with_global': 'content',
+        'default_value_should_not_override': 'content',
+        "default_value_empty": 'lvl0',
+        'default_value_empty_and_global': 'content',
+    }
+
+    def _get_actual_type(test_type):
+        return actual_type_variants.get(test_type)
+
+    return _get_actual_type
+
+
+@pytest.fixture
+def get_actual_lvl0():
+    actual_lvl0_variants = {
+        'default_value': 'Documentation',
+        'default_value_for_text': 'Foo',
+        'default_value_with_global': 'Documentation',
+        'default_value_should_not_override': 'Foo',
+        "default_value_empty": 'Documentation',
+        'default_value_empty_and_global': 'Documentation',
+    }
+
+    def _get_actual_lvl0(test_type):
+        return actual_lvl0_variants.get(test_type)
+
+    return _get_actual_lvl0
+
+
+@pytest.fixture
+def get_actual_content():
+    actual_content_variants = {
+        'default_value': 'text',
+        'default_value_for_text': 'Documentation',
+        'default_value_with_global': 'text',
+        'default_value_should_not_override': 'text',
+        "default_value_empty": None,
+        'default_value_empty_and_global': 'text',
+    }
+
+    def _get_actual_content(test_type):
+        return actual_content_variants.get(test_type)
+
+    return _get_actual_content
+
+
+@pytest.fixture
+def get_actual_len():
+    actual_len_variants = {
+        'default_value': 3,
+        'default_value_for_text': 3,
+        'default_value_with_global': 3,
+        'default_value_should_not_override': 3,
+        "default_value_empty": 4,
+        'default_value_empty_and_global': 3,
+    }
+
+    def _get_actual_len(test_type):
+        return actual_len_variants.get(test_type)
+
+    return _get_actual_len
+
+
+class TestGetRecordsFromDomWithDefaultValue:
+
+    @pytest.mark.parametrize('test_type',
+                             [
+                                 ('default_value'),
+                                 ('default_value_for_text'),
+                                 ('default_value_with_global'),
+                                 ('default_value_should_not_override'),
+                                 ('default_value_empty'),
+                                 ('default_value_empty_and_global'),
+                             ])
+    def test_default(self,
+                     get_selectors_lvl0,
+                     get_selectors_content,
+                     get_strategy_dom,
+                     get_actual_len,
+                     get_actual_type,
+                     get_actual_lvl0,
+                     get_actual_content,
+                     test_type):
+
+        # Given
+        strategy = get_strategy({
+            'selectors': {
+                'lvl0': get_selectors_lvl0(test_type),
+                'lvl1': 'h2',
+                'lvl2': 'h3',
+                'content': get_selectors_content(test_type)
+            }
+        })
+        strategy.dom = lxml.html.fromstring(get_strategy_dom(test_type))
 
         # When
         actual = strategy.get_records_from_dom()
+
         # Then
 
         # First record has the global H1
-        assert len(actual) == 3
-        assert actual[0]['type'] == 'content'
-        assert actual[0]['hierarchy']['lvl0'] == 'Documentation'
+        assert len(actual) == get_actual_len(test_type)
+        assert actual[0]['type'] == get_actual_type(test_type)
+        assert actual[0]['hierarchy']['lvl0'] == get_actual_lvl0(test_type)
         assert actual[0]['hierarchy']['lvl1'] is None
         assert actual[0]['hierarchy']['lvl2'] is None
-        assert actual[0]['content'] == 'text'
+        assert actual[0]['content'] == get_actual_content(test_type)

--- a/scraper/src/tests/default_strategy/get_hierarchy_radio_test.py
+++ b/scraper/src/tests/default_strategy/get_hierarchy_radio_test.py
@@ -1,12 +1,14 @@
 # coding: utf-8
-from .abstract import get_strategy
+import pytest
+
 from ...strategies.hierarchy import Hierarchy
+from .abstract import get_strategy
 
 
-class TestGetHierarchyRadio:
-    def test_toplevel(self):
-        # Given
-        hierarchy = {
+@pytest.fixture
+def get_hierarchy():
+    hierarchy_variants = {
+        'test_toplevel': {
             'lvl0': 'Foo',
             'lvl1': None,
             'lvl2': None,
@@ -14,25 +16,8 @@ class TestGetHierarchyRadio:
             'lvl4': None,
             'lvl5': None,
             'lvl6': None
-        }
-
-        # When
-        strategy = get_strategy()
-        actual = Hierarchy.get_hierarchy_radio(hierarchy, 'lvl0',
-                                               strategy.levels)
-
-        # Then
-        assert actual['lvl0'] == 'Foo'
-        assert actual['lvl1'] is None
-        assert actual['lvl2'] is None
-        assert actual['lvl3'] is None
-        assert actual['lvl4'] is None
-        assert actual['lvl5'] is None
-        assert actual['lvl6'] is None
-
-    def test_sublevel(self):
-        # Given
-        hierarchy = {
+        },
+        'test_sublevel': {
             'lvl0': 'Foo',
             'lvl1': 'Bar',
             'lvl2': 'Baz',
@@ -40,25 +25,8 @@ class TestGetHierarchyRadio:
             'lvl4': None,
             'lvl5': None,
             'lvl6': None
-        }
-
-        # When
-        strategy = get_strategy()
-        actual = Hierarchy.get_hierarchy_radio(hierarchy, 'lvl2',
-                                               strategy.levels)
-
-        # Then
-        assert actual['lvl0'] is None
-        assert actual['lvl1'] is None
-        assert actual['lvl2'] == 'Baz'
-        assert actual['lvl3'] is None
-        assert actual['lvl4'] is None
-        assert actual['lvl5'] is None
-        assert actual['lvl6'] is None
-
-    def test_contentlevel(self):
-        # Given
-        hierarchy = {
+        },
+        'test_contentlevel': {
             'lvl0': 'Foo',
             'lvl1': 'Bar',
             'lvl2': 'Baz',
@@ -66,17 +34,42 @@ class TestGetHierarchyRadio:
             'lvl4': None,
             'lvl5': None,
             'lvl6': None
-        }
+        },
+    }
+
+    def _get_hierarchy(test_type):
+        return hierarchy_variants.get(test_type)
+
+    return _get_hierarchy
+
+
+class TestGetHierarchyRadio:
+
+    @pytest.mark.parametrize('level, test_type',
+                             [
+                                 ('lvl0', 'test_toplevel'),
+                                 ('lvl2', 'test_sublevel'),
+                                 ('content', 'test_contentlevel'),
+                             ])
+    def test_get_hierarchy_radio(self, get_hierarchy, level, test_type):
+        # Given
+        hierarchy = get_hierarchy(test_type)
 
         # When
         strategy = get_strategy()
-        actual = Hierarchy.get_hierarchy_radio(hierarchy, 'content',
+        actual = Hierarchy.get_hierarchy_radio(hierarchy, level,
                                                strategy.levels)
 
         # Then
-        assert actual['lvl0'] is None
+        if test_type == 'test_toplevel':
+            assert actual['lvl0'] == 'Foo'
+        else:
+            assert actual['lvl0'] is None
         assert actual['lvl1'] is None
-        assert actual['lvl2'] is None
+        if test_type == 'test_sublevel':
+            assert actual['lvl2'] == 'Baz'
+        else:
+            assert actual['lvl2'] is None
         assert actual['lvl3'] is None
         assert actual['lvl4'] is None
         assert actual['lvl5'] is None

--- a/scraper/src/tests/default_strategy/page_rank_test.py
+++ b/scraper/src/tests/default_strategy/page_rank_test.py
@@ -1,19 +1,47 @@
 # coding: utf-8
 import lxml.html
+import pytest
+
 from .abstract import get_strategy
 
 
 class TestPageRank:
-    def test_default_page_rank_should_be_zero(self):
+
+    @pytest.mark.parametrize('page_rank, page_url',
+                             [
+                                 # test_default_page_rank_should_be_zero
+                                 (0, ''),
+                                 # test_positive_page_rank
+                                 (1, 'http://foo.bar/api'),
+                                 # test_positive_sub_page_page_rank
+                                 (1, 'http://foo.bar/api/test'),
+                                 # test_negative_page_rank
+                                 (-1, 'http://foo.bar/api/test'),
+                             ])
+    def test_page_rank(self, page_rank, page_url):
         # Given
-        strategy = get_strategy({
-            'selectors': {
-                "lvl0": "h1",
-                "lvl1": "h2",
-                "lvl2": "h3",
-                "content": "p"
-            }
-        })
+        if page_rank == 0:
+            strategy = get_strategy({
+                'selectors': {
+                    "lvl0": "h1",
+                    "lvl1": "h2",
+                    "lvl2": "h3",
+                    "content": "p"
+                }
+            })
+        else:
+            strategy = get_strategy({
+                'start_urls': [{
+                    'url': 'http://foo.bar/api',
+                    'page_rank': page_rank
+                }],
+                'selectors': {
+                    "lvl0": "h1",
+                    "lvl1": "h2",
+                    "lvl2": "h3",
+                    "content": "p"
+                }
+            })
 
         strategy.dom = lxml.html.fromstring("""
         <html><body>
@@ -22,88 +50,7 @@ class TestPageRank:
         """)
 
         # When
-        actual = strategy.get_records_from_dom()
+        actual = strategy.get_records_from_dom(page_url)
 
         # Then
-        assert actual[0]['weight']['page_rank'] == 0
-
-    def test_positive_page_rank(self):
-        # Given
-        strategy = get_strategy({
-            'start_urls': [{
-                'url': 'http://foo.bar/api',
-                'page_rank': 1
-            }],
-            'selectors': {
-                "lvl0": "h1",
-                "lvl1": "h2",
-                "lvl2": "h3",
-                "content": "p"
-            }
-        })
-
-        strategy.dom = lxml.html.fromstring("""
-        <html><body>
-         <h1>Foo</h1>
-        </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom("http://foo.bar/api")
-
-        # Then
-        assert actual[0]['weight']['page_rank'] == 1
-
-    def test_positive_sub_page_page_rank(self):
-        # Given
-        strategy = get_strategy({
-            'start_urls': [{
-                'url': 'http://foo.bar/api',
-                'page_rank': 1
-            }],
-            'selectors': {
-                "lvl0": "h1",
-                "lvl1": "h2",
-                "lvl2": "h3",
-                "content": "p"
-            }
-        })
-
-        strategy.dom = lxml.html.fromstring("""
-        <html><body>
-         <h1>Foo</h1>
-        </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom("http://foo.bar/api/test")
-
-        # Then
-        assert actual[0]['weight']['page_rank'] == 1
-
-    def test_negative_page_rank(self):
-        # Given
-        strategy = get_strategy({
-            'start_urls': [{
-                'url': 'http://foo.bar/api',
-                'page_rank': -1
-            }],
-            'selectors': {
-                "lvl0": "h1",
-                "lvl1": "h2",
-                "lvl2": "h3",
-                "content": "p"
-            }
-        })
-
-        strategy.dom = lxml.html.fromstring("""
-        <html><body>
-         <h1>Foo</h1>
-        </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom("http://foo.bar/api/test")
-
-        # Then
-        assert actual[0]['weight']['page_rank'] == -1
+        assert actual[0]['weight']['page_rank'] == page_rank

--- a/scraper/src/tests/default_strategy/strip_chars_test.py
+++ b/scraper/src/tests/default_strategy/strip_chars_test.py
@@ -1,28 +1,36 @@
 # coding: utf-8
 import lxml.html
+import pytest
+
 from .abstract import get_strategy
 
 
 class TestGetRecordsFromDomWithStripChars:
-    def test_strip_chars(self):
+
+    @pytest.mark.parametrize('selectors_lvl1, actual_lvl1',
+                             [
+                                 ('h2', '!Bar'),
+                                 ({'selector': 'h2', 'strip_chars': '!'}, 'Bar.'),
+                             ])
+    def test_strip_chars(self, selectors_lvl1, actual_lvl1):
         # Given
         strategy = get_strategy({
             'selectors': {
-                "lvl0": "h1",
-                "lvl1": "h2",
-                "lvl2": "h3",
-                "content": "p"
+                'lvl0': 'h1',
+                'lvl1': selectors_lvl1,
+                'lvl2': 'h3',
+                'content': 'p'
             },
             'strip_chars': ',.'
         })
-        strategy.dom = lxml.html.fromstring("""
+        strategy.dom = lxml.html.fromstring('''
         <html><body>
             <h1>.Foo;</h1>
             <h2>!Bar.</h2>
             <h3>,Baz!</h3>
             <p>,text,</p>
         </body></html>
-        """)
+        ''')
 
         # When
         actual = strategy.get_records_from_dom()
@@ -31,40 +39,6 @@ class TestGetRecordsFromDomWithStripChars:
         assert len(actual) == 4
         assert actual[3]['type'] == 'content'
         assert actual[3]['hierarchy']['lvl0'] == 'Foo;'
-        assert actual[3]['hierarchy']['lvl1'] == '!Bar'
-        assert actual[3]['hierarchy']['lvl2'] == 'Baz!'
-        assert actual[3]['content'] == 'text'
-
-    def test_strip_chars_with_level_override(self):
-        # Given
-        strategy = get_strategy({
-            'strip_chars': ',.',
-            'selectors': {
-                "lvl0": "h1",
-                "lvl1": {
-                    "selector": "h2",
-                    "strip_chars": "!"
-                },
-                "lvl2": "h3",
-                "content": "p"
-            }
-        })
-        strategy.dom = lxml.html.fromstring("""
-        <html><body>
-            <h1>.Foo;</h1>
-            <h2>!Bar.</h2>
-            <h3>,Baz!</h3>
-            <p>,text,</p>
-        </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom()
-
-        # Then
-        assert len(actual) == 4
-        assert actual[3]['type'] == 'content'
-        assert actual[3]['hierarchy']['lvl0'] == 'Foo;'
-        assert actual[3]['hierarchy']['lvl1'] == 'Bar.'
+        assert actual[3]['hierarchy']['lvl1'] == actual_lvl1
         assert actual[3]['hierarchy']['lvl2'] == 'Baz!'
         assert actual[3]['content'] == 'text'

--- a/scraper/src/tests/default_strategy/tags_test.py
+++ b/scraper/src/tests/default_strategy/tags_test.py
@@ -1,89 +1,44 @@
 # coding: utf-8
 import lxml.html
+import pytest
+
 from .abstract import get_strategy
 
 
 class TestTags:
-    def test_adding_tags_for_page(self):
+
+    @pytest.mark.parametrize('start_url, actual_url',
+                             [
+                                 # test_adding_tags_for_page
+                                 ('http://foo.bar/api', 'http://foo.bar/api'),
+                                 # test_adding_tags_for_subpage
+                                 ('http://foo.bar/api', 'http://foo.bar/api/test'),
+                                 # test_regex_start_urls
+                                 ('http://foo.bar/*', 'http://foo.bar/api/test'),
+                             ])
+    def test_tags(self, start_url, actual_url):
         # Given
         strategy = get_strategy({
             'start_urls': [{
-                'url': 'http://foo.bar/api',
-                'tags': ["test"]
+                'url': start_url,
+                'tags': ['test']
             }],
             'selectors': {
-                "lvl0": "h1",
-                "lvl1": "h2",
-                "lvl2": "h3",
-                "content": "p"
+                'lvl0': 'h1',
+                'lvl1': 'h2',
+                'lvl2': 'h3',
+                'content': 'p'
             }
         })
 
-        strategy.dom = lxml.html.fromstring("""
+        strategy.dom = lxml.html.fromstring('''
         <html><body>
          <h1>Foo</h1>
         </body></html>
-        """)
+        ''')
 
         # When
-        actual = strategy.get_records_from_dom("http://foo.bar/api")
+        actual = strategy.get_records_from_dom(actual_url)
 
         # Then
-        assert actual[0]['tags'] == ["test"]
-
-    def test_adding_tags_for_subpage(self):
-        # Given
-        strategy = get_strategy({
-            'selectors': {
-                "lvl0": "h1",
-                "lvl1": "h2",
-                "lvl2": "h3",
-                "content": "p"
-            },
-            'start_urls': [{
-                'url': 'http://foo.bar/api',
-                'tags': ["test"]
-            }]
-        })
-
-        strategy.dom = lxml.html.fromstring("""
-        <html><body>
-         <h1>Foo</h1>
-        </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom("http://foo.bar/api/test")
-
-        # Then
-        assert actual[0]['tags'] == ["test"]
-
-    def test_regex_start_urls(self):
-        # Given
-        # Stub ENV variables read by ConfigLoader
-        strategy = get_strategy({
-            'start_urls': [
-                {
-                    'url': 'http://foo.bar/.*',
-                    'tags': ["test"]
-                }
-            ],
-            'selectors': {
-                "lvl0": "h1",
-                "lvl1": "h2",
-                "lvl2": "h3",
-                "content": "p"
-            }
-        })
-
-        strategy.dom = lxml.html.fromstring("""
-        <html><body>
-         <h1>Foo</h1>
-        </body></html>
-        """)
-
-        # When
-        actual = strategy.get_records_from_dom("http://foo.bar/api/test")
-
-        # Then
-        assert actual[0]['tags'] == ["test"]
+        assert actual[0]['tags'] == ['test']


### PR DESCRIPTION
Fix #114

Linter errors are caused by duplicate code in tests.
I suggest parameterising the tests with @pytest.mark.parametrize and @pytest.fixtures. Then common fixtures can be put in conftest.py
