### PR TITLE
Add libnss3 package to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
 RUN apt-get update -y \
-    && apt-get install -y python3-pip
+    && apt-get install -y python3-pip libnss3
+
 RUN pip3 install pipenv
 RUN pipenv --python 3.8 install


### PR DESCRIPTION
Following the discussions about this issue https://github.com/meilisearch/docs-scraper/issues/139 and after running this #165 locally, I had some trouble using `chrome_webdriver` because my `Dockerfile` didn't have this package.

This is not a fix for the mentioned issue, is just a small part of it!