### PR TITLE
Fix: Delete index before starting scrapping

### DIFF
--- a/scraper/src/meilisearch_helper.py
+++ b/scraper/src/meilisearch_helper.py
@@ -101,11 +101,15 @@ class MeiliSearchHelper:
     def __init__(self, host_url, api_key, index_uid, custom_settings):
         self.meilisearch_client = meilisearch.Client(host_url, api_key)
         self.meilisearch_index = self.meilisearch_client.index(index_uid)
+        self.delete_index()
         self.add_settings(MeiliSearchHelper.SETTINGS, custom_settings)
 
     def add_settings(self, default_settings, custom_settings):
         settings = {**default_settings, **custom_settings}
         self.meilisearch_index.update_settings(settings)
+
+    def delete_index(self):
+        self.meilisearch_index.delete()
 
     def add_records(self, records, url, from_sitemap):
         """Add new records to the index"""


### PR DESCRIPTION
# Pull Request

The index should be deleted before the start of a new scraping. This is important as we do not want to keep scrapped page that does not exists anymore. 