### PR TITLE
Chromium-driver binary is added to Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
 FROM python:3.8.4-buster
 
-WORKDIR /docs-scraper
-
-COPY . .
-
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
+WORKDIR /docs-scraper
+
 RUN apt-get update -y \
-    && apt-get install -y python3-pip libnss3
+    && apt-get install -y python3-pip libnss3 \
+    && apt-get install -y chromium-driver
 
 RUN pip3 install pipenv
+
+
+COPY Pipfile Pipfile
+COPY Pipfile.lock Pipfile.lock 
+
 RUN pipenv --python 3.8 install
+
+
+COPY . . 

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 Scrapy = "==2.6.1"
 selenium = "==4.1.5"
 pytest = "==7.1.2"
-meilisearch = "==0.18.3"
+meilisearch = "==0.19.1"
 requests-iap = "==0.2.0"
 python-keycloak-client = "==0.2.3"
 


### PR DESCRIPTION
## What does this PR do?
Fixes #185 (**1 task**)

Dockerfile was updated as follows:
1. **Chromium-driver** was installed using [debian repo](https://packages.debian.org/buster/chromium-driver).
2. The speed of build process was optimized by leveraging build cache ([more](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache)). 

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


Hope you're doing great,
Matthew