### PR TITLE
Using 'Authorization: Bearer' according to rfc6750

### DIFF
--- a/scraper/src/index.py
+++ b/scraper/src/index.py
@@ -77,7 +77,7 @@ def run_config(config):
           client_secret=os.getenv("KC_CLIENT_SECRET"))
         token_response = oidc_client.client_credentials()
         token = token_response["access_token"]
-        headers.update({"Authorization": 'bearer ' + token})
+        headers.update({"Authorization": 'Bearer ' + token})
 
     DEFAULT_REQUEST_HEADERS = headers
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This pr fixes the authorization header when authenticating against resources protected by gatekeeper.
According to https://datatracker.ietf.org/doc/html/rfc6750#section-2.1 the authorization header must follow the convention `Authorization: Bearer <token>`