### PR TITLE
Enhancement/Action tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,18 +12,22 @@ on:
 jobs:
   linter:
     name: linter
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install pipenv
         run: pipx install pipenv
-      - name: Set up Python 3.8
+
+      - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
           cache: "pipenv"
+
       - name: Install dependencies
         run: pipenv install --dev
+
       - name: Linter with pylint
         run: pipenv run pylint scraper
 
@@ -31,59 +35,68 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.9", "3.10", "3.11"]
     name: unit-tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install pipenv
         run: pipx install pipenv
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pipenv"
+
       - name: Install dependencies
         run: pipenv install --dev
+
       - name: Run tests
         run: pipenv run pytest -m "not chromedriver"
 
   integration_tests:
+    env:
+      MEILISEARCH_HOST_URL: "http://127.0.0.1:7700"
+      MEILISEARCH_API_KEY: "masterKey"
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ["3.9", "3.10", "3.11"]
     name: integration-tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Install pipenv
         run: pipx install pipenv
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pipenv"
+
       - name: Install dependencies for production only
         run: pipenv install
+
       - name: Meilisearch setup with Docker
         run: docker run -d -p 7700:7700 getmeili/meilisearch:latest meilisearch --no-analytics --master-key=masterKey
+
       - name: Run the scraper with basic config
         run: pipenv run ./docs_scraper $CONFIG_FILE
         env:
-          MEILISEARCH_HOST_URL: "http://127.0.0.1:7700"
-          MEILISEARCH_API_KEY: "masterKey"
           CONFIG_FILE: "tests/config_files_examples/docs-basics.config.json"
+
       - name: Run the scraper with custom config
         run: pipenv run ./docs_scraper $CONFIG_FILE
         env:
-          MEILISEARCH_HOST_URL: "http://127.0.0.1:7700"
-          MEILISEARCH_API_KEY: "masterKey"
           CONFIG_FILE: "tests/config_files_examples/docs-custom.config.json"
 
   image_build:
     name: image-build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Build Docker image

--- a/bors.toml
+++ b/bors.toml
@@ -1,8 +1,10 @@
 status = [
-  'unit-tests (3.8)',
   'unit-tests (3.9)',
-  'integration-tests (3.8)',
+  'unit-tests (3.10)',
+  'unit-tests (3.11)',
   'integration-tests (3.9)',
+  'integration-tests (3.10)',
+  'integration-tests (3.11)',
   'linter',
   'image-build',
 ]


### PR DESCRIPTION
Fixes #290 

I think we can keep the last three minor releases of Python. This PR adds those last three minors to `unit_tests` and `integration_tests` actions.
The linter action runs only against the python version we have in the final docker image.