### PR TITLE
Update version file path

### DIFF
--- a/.github/scripts/check-release.sh
+++ b/.github/scripts/check-release.sh
@@ -2,7 +2,7 @@
 
 # Checking if current tag matches the package version
 current_tag=$(echo $GITHUB_REF | cut -d '/' -f 3 | sed -r 's/^v//')
-file_tag=$(grep '__version__ =' meilisearch/version.py | cut -d '=' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
+file_tag=$(grep '__version__ =' scraper/src/config/version.py | cut -d '=' -f 2- | tr -d ' ' | tr -d '"' | tr -d ',')
 if [ "$current_tag" != "$file_tag" ]; then
   echo "Error: the current tag does not match the version in package file(s)."
   echo "$current_tag vs $file_tag"


### PR DESCRIPTION
# Pull Request

@alallema I saw the publish to docker hub failed. I think the version check script should point to the version file for `docs-scraper` and not `meilisearch-python`?

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Updates the path to the version file

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
