### PR TITLE
Reduce docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# Build artifacts
+build/
+dist/
+
+# Git/GitHub
+.git/
+.github/
+.gitignore
+
+# Python specific files
+**/__pycache__
+**/.mypy_cache/
+**/.pylintrc/
+**/.pytest_cache/
+**/*.py[cod]
+**/*.egg
+**/tests/
+pytest.ini
+tox.ini
+
+# C extensions
+*.so
+
+# pyenv
+**/.python-version
+
+# Virtual Environments
+**/.env
+**/.venv
+**/env/
+**/venv/
+
+# Editors
+**/.vscode/
+**/.idea/
+
+# Docker
+docker-compose.yml
+docker-compose.yaml
+Dockerfile
+
+# Project files
+.editorconfig
+bors.toml
+CONTRIBUTING.md
+README.md
+assets/
+
+# System files
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,15 @@ ENV LANG C.UTF-8
 
 WORKDIR /docs-scraper
 
-RUN apt-get update -y && apt-get install -y python3-pip libnss3 chromium-driver
+RUN : \
+  && apt-get update -y \
+  && apt-get install -y --no-install-recommends \
+  libnss3 \
+  chromium-driver \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install pipenv
+RUN pip install -U pip && pip install pipenv --no-cache-dir
 
 COPY Pipfile Pipfile
 COPY Pipfile.lock Pipfile.lock


### PR DESCRIPTION
# Pull Request

With these changes I got ~ a 43% reduction in the final image size (1.55GB to 877MB). Note that depending on your local files present (virtual environments, etc) you may see slightly different numbers with a build, but it will always be significantly smaller.

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Cleans up the `apt-get install` section
- Adds a `.dockerignore` file
- Removes the separate install of `pip3`. Because the image is `python:3.10.8-slim-bullseye` `pip` is already included by default

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
