### PR TITLE
Refactor version test

### DIFF
--- a/tests/meilisearch_helper/meilisearch_helper_test.py
+++ b/tests/meilisearch_helper/meilisearch_helper_test.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 import requests
 
-from scraper.src.meilisearch_helper import MeiliSearchHelper
 from scraper.src.config.version import __version__
+from scraper.src.meilisearch_helper import MeiliSearchHelper
 from tests.meilisearch_helper import common
 
 
@@ -34,4 +34,7 @@ class TestMeilisearchHelper:
             )
 
         # Then
-        assert actual.meilisearch_client.http.headers['User-Agent'] == f"Meilisearch Python (v0.27.0);Meilisearch DocsScraper (v{__version__})"
+        split_version = actual.meilisearch_client.http.headers['User-Agent'].split(";")
+        assert len(split_version) == 2
+        assert split_version[0].startswith("Meilisearch Python (") is True
+        assert split_version[1] == f"Meilisearch DocsScraper (v{__version__})"


### PR DESCRIPTION
# Pull Request

@alallema we basically had the same idea. Since we know the expected format my thinking here is the first item in the list should start with `Meilisearch Python (`, then the specific version is already tested in `meilisearch-python` so we can trust that is correct.

## Related issue
Discussed in #396

## What does this PR do?
- Makes it where the test won't fail with every update to `meilisearch-python`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
