### PR TITLE
Add back chromedriver tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install Chromium
+        run: apt update && apt install -y chromium
+
       - name: Install pipenv
         run: pipx install pipenv
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Chromium
-        run: sudo apt-get update && sudo apt-get install -y chromium
+        run: sudo apt-get update && sudo apt-get install -y chromium-browser
 
       - name: Install pipenv
         run: pipx install pipenv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Chromium
-        run: apt update && apt install -y chromium
+        run: sudo apt-get update && sudo apt-get install -y chromium
 
       - name: Install pipenv
         run: pipx install pipenv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install Chromium
-        run: sudo apt-get update && sudo apt-get install -y chromium-browser
+        run: sudo apt-get update && sudo apt-get install -y chromium-browser chromium-chromedriver
 
       - name: Install pipenv
         run: pipx install pipenv

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         run: pipenv install --dev
 
       - name: Run tests
-        run: pipenv run pytest -m "not chromedriver"
+        run: pipenv run pytest
 
   integration_tests:
     env:

--- a/scraper/src/js_executor.py
+++ b/scraper/src/js_executor.py
@@ -1,5 +1,5 @@
-import time
 import json
+import time
 
 
 class JsExecutor:

--- a/tests/config_loader/get_extra_facets_test.py
+++ b/tests/config_loader/get_extra_facets_test.py
@@ -2,8 +2,10 @@
 import pytest
 
 from scraper.src.config.config_loader import ConfigLoader
+
 from .abstract import config
 from .mocked_init import MockedInit
+
 
 class TestGetExtraFacets:
     def test_extra_facets_should_be_empty_by_default(self):
@@ -14,7 +16,7 @@ class TestGetExtraFacets:
         assert actual.get_extra_facets() == []
 
     @pytest.mark.chromedriver
-    @pytest.mark.usefixtures("chromedriver")
+    # @pytest.mark.usefixtures("chromedriver")
     def test_extra_facets_should_be_set_from_start_urls_variables_browser(self,
                                                                           monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",
@@ -38,7 +40,7 @@ class TestGetExtraFacets:
         assert actual.get_extra_facets() == ["type_of_content"]
 
     @pytest.mark.chromedriver
-    @pytest.mark.usefixtures("chromedriver")
+    # @pytest.mark.usefixtures("chromedriver")
     def test_extra_facets_should_be_set_from_start_urls_variables_with_two_start_url_browser(
             self, monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",
@@ -69,7 +71,7 @@ class TestGetExtraFacets:
         assert actual.get_extra_facets() == ["type_of_content"]
 
     @pytest.mark.chromedriver
-    @pytest.mark.usefixtures("chromedriver")
+    # @pytest.mark.usefixtures("chromedriver")
     def test_extra_facets_should_be_set_from_start_urls_variables_with_multiple_tags_browser(
             self, monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",

--- a/tests/config_loader/get_extra_facets_test.py
+++ b/tests/config_loader/get_extra_facets_test.py
@@ -16,7 +16,6 @@ class TestGetExtraFacets:
         assert actual.get_extra_facets() == []
 
     @pytest.mark.chromedriver
-    # @pytest.mark.usefixtures("chromedriver")
     def test_extra_facets_should_be_set_from_start_urls_variables_browser(self,
                                                                           monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",
@@ -40,7 +39,6 @@ class TestGetExtraFacets:
         assert actual.get_extra_facets() == ["type_of_content"]
 
     @pytest.mark.chromedriver
-    # @pytest.mark.usefixtures("chromedriver")
     def test_extra_facets_should_be_set_from_start_urls_variables_with_two_start_url_browser(
             self, monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",
@@ -71,7 +69,6 @@ class TestGetExtraFacets:
         assert actual.get_extra_facets() == ["type_of_content"]
 
     @pytest.mark.chromedriver
-    # @pytest.mark.usefixtures("chromedriver")
     def test_extra_facets_should_be_set_from_start_urls_variables_with_multiple_tags_browser(
             self, monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",

--- a/tests/config_loader/open_selenium_browser_test.py
+++ b/tests/config_loader/open_selenium_browser_test.py
@@ -18,7 +18,6 @@ class TestOpenSeleniumBrowser:
                                                 actual.js_render) is False
 
     @pytest.mark.chromedriver
-    # @pytest.mark.usefixtures("chromedriver")
     def test_browser_needed_when_js_render_true(self, monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",
                             lambda x: MockedInit())
@@ -33,7 +32,7 @@ class TestOpenSeleniumBrowser:
                                                 actual.js_render) is True
 
     @pytest.mark.chromedriver
-    # @pytest.mark.usefixtures("chromedriver")
+    @pytest.mark.xfail(strict=True)
     def test_browser_needed_when_config_contains_automatic_tag(self,
                                                                monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",

--- a/tests/config_loader/open_selenium_browser_test.py
+++ b/tests/config_loader/open_selenium_browser_test.py
@@ -1,8 +1,9 @@
 # coding: utf-8
 import pytest
 
-from scraper.src.config.config_loader import ConfigLoader
 from scraper.src.config.browser_handler import BrowserHandler
+from scraper.src.config.config_loader import ConfigLoader
+
 from .abstract import config
 from .mocked_init import MockedInit
 
@@ -17,7 +18,7 @@ class TestOpenSeleniumBrowser:
                                                 actual.js_render) is False
 
     @pytest.mark.chromedriver
-    @pytest.mark.usefixtures("chromedriver")
+    # @pytest.mark.usefixtures("chromedriver")
     def test_browser_needed_when_js_render_true(self, monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",
                             lambda x: MockedInit())
@@ -32,7 +33,7 @@ class TestOpenSeleniumBrowser:
                                                 actual.js_render) is True
 
     @pytest.mark.chromedriver
-    @pytest.mark.usefixtures("chromedriver")
+    # @pytest.mark.usefixtures("chromedriver")
     def test_browser_needed_when_config_contains_automatic_tag(self,
                                                                monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",

--- a/tests/config_loader/start_urls_test.py
+++ b/tests/config_loader/start_urls_test.py
@@ -2,6 +2,7 @@
 import pytest
 
 from scraper.src.config.config_loader import ConfigLoader
+
 from .abstract import config
 from .mocked_init import MockedInit
 
@@ -70,7 +71,7 @@ class TestStartUrls:
         assert actual.start_urls[0]['url'] == 'http://www.foo.bar/'
 
     @pytest.mark.chromedriver
-    @pytest.mark.usefixtures("chromedriver")
+    # @pytest.mark.usefixtures("chromedriver")
     def test_start_urls_should_be_generated_when_there_is_automatic_tagging_browser(
             self, monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",

--- a/tests/config_loader/start_urls_test.py
+++ b/tests/config_loader/start_urls_test.py
@@ -71,7 +71,6 @@ class TestStartUrls:
         assert actual.start_urls[0]['url'] == 'http://www.foo.bar/'
 
     @pytest.mark.chromedriver
-    # @pytest.mark.usefixtures("chromedriver")
     def test_start_urls_should_be_generated_when_there_is_automatic_tagging_browser(
             self, monkeypatch):
         monkeypatch.setattr("selenium.webdriver.chrome",


### PR DESCRIPTION
# Pull Request

@alallema I saw the publish to docker hub failed. I think the version check script should point to the version file for `docs-scraper` and not `meilisearch-python`?

## Related issue
Fixes #177

## What does this PR do?
- Adds the chromedriver tests back to CI

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
