### PR TITLE
Update dependabot updates interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,9 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: daily
+    interval: "monthly"
     time: "04:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 15
   labels:
   - skip-changelog
   - dependencies


### PR DESCRIPTION
Change dependabot configuration to monthly.

Related to: https://github.com/meilisearch/integration-guides/issues/283